### PR TITLE
use delegating Makefile and add _CoqProject and .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+Makefile.coq
+Makefile.coq.conf
+*~
+*.d
+*.aux
+*.glob
+*.vo
+*.vio
+*.vok
+*.vos
+.lia.cache

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,16 @@
-# Makefile for Coq project
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
 
-# Variables
-COQC = coqc
-COQFLAGS = -Q . ""
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
-# Dependencies
-all: mk_theorems.vo
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-mk_structure.vo: mk_structure.v
-	$(COQC) $(COQFLAGS) mk_structure.v
+force _CoqProject Makefile: ;
 
-mk_theorems.vo: mk_structure.vo mk_theorems.v
-	$(COQC) $(COQFLAGS) mk_theorems.v
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
 
-install: all
-	@mkdir -p /usr/local/coq
-	@cp *.vo *.glob /usr/local/coq
-	@echo "Files installed to /usr/local/coq"
-
-clean:
-	rm -f *.vo *.glob
+.PHONY: all clean force

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,4 @@
+-R . MorseKelley
+
+mk_structure.v
+mk_theorems.v


### PR DESCRIPTION
To enable building a proper Coq package using the `make install` target, we recommend using the `coq_makefile` tool bundled with Coq. Here I set up a basic delegating `Makefile` that uses `coq_makefile`. Using something like this is a prerequisite for getting the package merged into the Coq opam archive as per https://github.com/coq/opam/pull/3116